### PR TITLE
allow usage in rails 7.1.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        activesupport: ['6.1', '7.0']
+        activesupport: ['6.1', '7.0', '7.1']
         ruby: ['2.7', '3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v2

--- a/ja2r.gemspec
+++ b/ja2r.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'README.md']
 
-  s.add_dependency 'activesupport', '>= 6.1', '< 7.1'
+  s.add_dependency 'activesupport', '>= 6.1', '< 7.2'
 
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'rubocop', '1.50.2'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ ENV['RACK_ENV'] = 'test'
 
 require 'rubygems'
 require 'bundler'
-Bundler.require :default, 'test'
+Bundler.require :default, 'development', 'test'
 
 require 'simplecov'
 SimpleCov.start


### PR DESCRIPTION
Currently the gem can only be used in rails <= 7.0 apps.

This change will widen the dependency spec to include 7.1.x.